### PR TITLE
Added JavaDocs item in menu bar

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -31,6 +31,11 @@ module.exports = {
           position: "left",
         },
         {
+          href: "https://cloudnetservice.eu/cloudnet/docs/",
+          label: "JavaDocs",
+          position: "left",
+        },
+        {
           type: "docsVersionDropdown",
           position: "right",
         },


### PR DESCRIPTION
Added the link https://cloudnetservice.eu/cloudnet/docs/ to the menu bar.

Suggestion:
https://discord.com/channels/325362837184577536/536594865530601483/949047460301537330